### PR TITLE
Increase flip interval in game server to 10 sec

### DIFF
--- a/server/game.js
+++ b/server/game.js
@@ -30,8 +30,7 @@
 //                    BLUE)
 // FLIP_INTERVAL    = The number of milliseconds the server will wait
 //                    before flipping colors (from RED to BLUE, or
-//                    vice-versa). 2000 ms works pretty well without there
-//                    being problems.  Smaller values will make sure that
+//                    vice-versa). Smaller values will make sure that
 //                    inactive users are kicked out promptly, but also
 //                    increases the chance of active users getting kicked
 //                    out as well (since they have less time to update
@@ -46,7 +45,7 @@
 RED = 1;
 BLUE = 0;
 SERVER_COLOR = RED;
-FLIP_INTERVAL = 2000;
+FLIP_INTERVAL = 10000;
 FIRST_RUN = true;
 
 //==================================================================


### PR DESCRIPTION
This is to fix a problem where people's votes weren't getting registered because they were getting kicked out of the server too fast.

Now with this way, the votes of people who have already closed the browser will stay in longer (10 sec, to be exact), but it has a far reduced chance of not registering someone's valid vote.
